### PR TITLE
writing once instead multiple times

### DIFF
--- a/fingerprinting/k8s_dump.sh
+++ b/fingerprinting/k8s_dump.sh
@@ -1,1 +1,1 @@
-for res in $(kubectl api-resources -o name);do kubectl get $res -o yaml | tee -a k8s.dump;done
+for res in $(kubectl api-resources -o name);do kubectl get "${res}" -o yaml ; done | tee k8s.dump


### PR DESCRIPTION
Saw our [tweet](https://twitter.com/secureideas/status/1344342682743795714?s=19) recently and remembered there was a small optimization you could do on your [blog post](https://blog.secureideas.com/2020/03/kubernetes-security-a-useful-bash-one-liner.html).

Instead of appending to the file after every `get`, you could just have the pipe after the for loop and it will write all the contents of the for loop to the file. That way if you ( the royal you ( as in anyone who is running this ) ) are running the command and have a slow disk it will all be written at once instead of multiple writes.

I also wrapped your variable a bit "safer", so that way if ( which I know there aren't currently ) there are any spaces in a word it doesn't try and split it as arguments. 